### PR TITLE
Fix assertion due to multiple calls to locationManagerDidChangeAuthorization

### DIFF
--- a/Sources/Locations/Types/LocationManagerDelegate/LocationManagerDelegate.swift
+++ b/Sources/Locations/Types/LocationManagerDelegate/LocationManagerDelegate.swift
@@ -32,6 +32,7 @@ extension LocationManagerDelegate: CLLocationManagerDelegate {
 		let status: AuthorizationStatus = .init(manager.authStatus)
 		
 		self.authorizationContinuation?.resume(returning: status)
+        self.authorizationContinuation = nil
 	}
 }
 

--- a/Sources/Locations/Types/LocationManagerDelegate/LocationManagerDelegate.swift
+++ b/Sources/Locations/Types/LocationManagerDelegate/LocationManagerDelegate.swift
@@ -32,7 +32,7 @@ extension LocationManagerDelegate: CLLocationManagerDelegate {
 		let status: AuthorizationStatus = .init(manager.authStatus)
 		
 		self.authorizationContinuation?.resume(returning: status)
-        self.authorizationContinuation = nil
+		self.authorizationContinuation = nil
 	}
 }
 


### PR DESCRIPTION
Continuations can only resume once, but the delegate method can be called multiple times. Remove reference to continuation once resumed.